### PR TITLE
Increase `GameBoard` size for smaller screens, add additional wrapper for `GameOverlay`

### DIFF
--- a/app/components/GameBoard.tsx
+++ b/app/components/GameBoard.tsx
@@ -78,12 +78,14 @@ const GameBoard = ({
   }, [drawGameBoard]);
 
   return (
-    <div className="relative flex justify-center rounded-lg bg-green-400 p-4">
-      <canvas ref={canvasRef} />
+    <div className="flex justify-center rounded-lg bg-green-400 p-4">
+      <div className="relative">
+        <canvas ref={canvasRef} />
 
-      {(!isGameStarted || isGamePaused) && (
-        <GameOverlay isGameStarted={isGameStarted} />
-      )}
+        {(!isGameStarted || isGamePaused) && (
+          <GameOverlay isGameStarted={isGameStarted} />
+        )}
+      </div>
     </div>
   );
 };

--- a/app/hooks/useResponsiveSize.ts
+++ b/app/hooks/useResponsiveSize.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
 
+const SMALLER_CANVAS_SIZE = 480;
+const LARGER_CANVAS_SIZE = 645;
+
 const useResponsiveSize = () => {
   const [canvasSize, setCanvasSize] = useState(650);
 
@@ -9,9 +12,9 @@ const useResponsiveSize = () => {
       const screenHeight = window.innerHeight;
 
       if (screenWidth >= 1024 && screenHeight >= 800) {
-        setCanvasSize(645);
+        setCanvasSize(LARGER_CANVAS_SIZE);
       } else {
-        setCanvasSize(450);
+        setCanvasSize(SMALLER_CANVAS_SIZE);
       }
     };
 


### PR DESCRIPTION
- Increased `GameBoard` size from `450` to `480` for smaller screens
- Added additional wrapper for `GameOverlay`, so that it would render directly on top of `canvas`